### PR TITLE
Use HoppingCursor instead of potentially undefined Cursor.

### DIFF
--- a/autoload/hopping.vim
+++ b/autoload/hopping.vim
@@ -117,7 +117,7 @@ function! s:on_search_pattern(pat, ...)
 	else
 		call s:Highlight.highlight("search", "Search", a:pat)
 	endif
-	call s:Highlight.highlight("cursor", "Cursor", s:Position.as_pattern(pos))
+	call s:Highlight.highlight("cursor", "HoppingCursor", s:Position.as_pattern(pos))
 endfunction
 
 


### PR DESCRIPTION
Code to fix issue https://github.com/osyo-manga/vim-hopping/issues/2 was added by https://github.com/osyo-manga/vim-hopping/commit/e2496c80b266f5910f1c4a2215b183bb697efb59, but I think a legacy usage of `Cursor` was left behind.

This PR fixes that. Confirmed it works on Vim8
